### PR TITLE
Constant time everything

### DIFF
--- a/src/fr.rs
+++ b/src/fr.rs
@@ -324,25 +324,21 @@ impl Fr {
     }
 
     /// Computes the square root of this element, if it exists.
-    ///
-    /// **This operation is variable time.**
-    pub fn sqrt_vartime(&self) -> Option<Self> {
+    pub fn sqrt(&self) -> Maybe<Self> {
         // Because r = 3 (mod 4)
         // sqrt can be done with only one exponentiation,
         // via the computation of  self^((r + 1) // 4) (mod r)
-        // a1 = self^((r - 3) // 4)
-        let a1 = self.pow_vartime(&[
-            0xb425c397b5bdcb2d,
+        let sqrt = self.pow_vartime(&[
+            0xb425c397b5bdcb2e,
             0x299a0824f3320420,
             0x4199cec0404d0ec0,
-            0x039f6d3a994cebea,
+            0x039f6d3a994cebea
         ]);
-        let a0 = a1 * (a1 * self);
-        if a0 == -Self::one() {
-            None
-        } else {
-            Some(a1 * self)
-        }
+
+        Maybe::new(
+            sqrt,
+            (&sqrt * &sqrt).ct_eq(self) // Only return Some if it's the square root.
+        )
     }
 
     /// Exponentiates `self` by `by`, where `by` is a
@@ -924,8 +920,8 @@ fn test_sqrt() {
     let mut none_count = 0;
 
     for _ in 0..100 {
-        let square_root = square.sqrt_vartime();
-        if square_root.is_none() {
+        let square_root = square.sqrt();
+        if square_root.is_none().unwrap_u8() == 1 {
             none_count += 1;
         } else {
             assert_eq!(square_root.unwrap() * square_root.unwrap(), square);

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -2,8 +2,10 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use byteorder::{ByteOrder, LittleEndian};
-use crate::util::{adc, mac, sbb};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+use crate::util::{adc, mac, sbb};
+use crate::maybe::Maybe;
 
 /// Represents an element of `GF(r)`.
 // The internal representation of this type is four 64-bit unsigned
@@ -215,9 +217,7 @@ impl Fr {
     /// Attempts to convert a little-endian byte representation of
     /// a field element into an element of `Fr`, failing if the input
     /// is not canonical (is not smaller than r).
-    ///
-    /// **This operation is variable time.**
-    pub fn from_bytes_vartime(bytes: [u8; 32]) -> Option<Fr> {
+    pub fn from_bytes(bytes: [u8; 32]) -> Maybe<Fr> {
         let mut tmp = Fr([0, 0, 0, 0]);
 
         tmp.0[0] = LittleEndian::read_u64(&bytes[0..8]);
@@ -225,23 +225,22 @@ impl Fr {
         tmp.0[2] = LittleEndian::read_u64(&bytes[16..24]);
         tmp.0[3] = LittleEndian::read_u64(&bytes[24..32]);
 
-        // Check if the value is in the field
-        for i in (0..4).rev() {
-            if tmp.0[i] < MODULUS.0[i] {
-                // Convert to Montgomery form by computing
-                // (a.R^{-1} * R^2) / R = a.R
-                tmp.mul_assign(&R2);
+        // Try to subtract the modulus
+        let (_, borrow) = sbb(tmp.0[0], MODULUS.0[0], 0);
+        let (_, borrow) = sbb(tmp.0[1], MODULUS.0[1], borrow);
+        let (_, borrow) = sbb(tmp.0[2], MODULUS.0[2], borrow);
+        let (_, borrow) = sbb(tmp.0[3], MODULUS.0[3], borrow);
 
-                return Some(tmp);
-            }
+        // If the element is smaller than MODULUS then the
+        // subtraction will underflow, producing a borrow value
+        // of 0xffff...ffff. Otherwise, it'll be zero.
+        let is_some = (borrow as u8) & 1;
 
-            if tmp.0[i] > MODULUS.0[i] {
-                return None;
-            }
-        }
+        // Convert to Montgomery form by computing
+        // (a.R^{-1} * R^2) / R = a.R
+        tmp *= &R2;
 
-        // Value is equal to the modulus
-        None
+        Maybe::new(tmp, Choice::from(is_some))
     }
 
     /// Converts an element of `Fr` into a byte representation in
@@ -621,9 +620,9 @@ fn test_into_bytes() {
 }
 
 #[test]
-fn test_from_bytes_vartime() {
+fn test_from_bytes() {
     assert_eq!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
         ]).unwrap(),
@@ -631,7 +630,7 @@ fn test_from_bytes_vartime() {
     );
 
     assert_eq!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0
         ]).unwrap(),
@@ -639,7 +638,7 @@ fn test_from_bytes_vartime() {
     );
 
     assert_eq!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             217, 7, 150, 185, 179, 11, 248, 37, 80, 231, 182, 102, 47, 214, 21, 243, 244, 20, 136,
             235, 238, 20, 37, 147, 198, 85, 145, 71, 111, 252, 166, 9
         ]).unwrap(),
@@ -648,40 +647,40 @@ fn test_from_bytes_vartime() {
 
     // -1 should work
     assert!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             182, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
-        ]).is_some()
+        ]).is_some().unwrap_u8() == 1
     );
 
     // modulus is invalid
     assert!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
-        ]).is_none()
+        ]).is_none().unwrap_u8() == 1
     );
 
     // Anything larger than the modulus is invalid
     assert!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             184, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 14
-        ]).is_none()
+        ]).is_none().unwrap_u8() == 1
     );
 
     assert!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 104, 6, 169, 175, 51, 101, 234, 180, 125, 14
-        ]).is_none()
+        ]).is_none().unwrap_u8() == 1
     );
 
     assert!(
-        Fr::from_bytes_vartime([
+        Fr::from_bytes([
             183, 44, 247, 214, 94, 14, 151, 208, 130, 16, 200, 204, 147, 32, 104, 166, 0, 59, 52,
             1, 1, 59, 103, 6, 169, 175, 51, 101, 234, 180, 125, 15
-        ]).is_none()
+        ]).is_none().unwrap_u8() == 1
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl From<ExtendedPoint> for AffinePoint {
     fn from(extended: ExtendedPoint) -> AffinePoint {
         // Z coordinate is always nonzero, so this is
         // its inverse.
-        let zinv = extended.z.invert_nonzero();
+        let zinv = extended.z.invert().unwrap();
 
         AffinePoint {
             u: extended.u * &zinv,
@@ -317,7 +317,7 @@ impl AffinePoint {
 
             let v2 = v.square();
 
-            ((v2 - Fq::one()) * (Fq::one() + EDWARDS_D * &v2).invert_nonzero())
+            ((v2 - Fq::one()) * (Fq::one() + EDWARDS_D * &v2).invert().unwrap())
             .sqrt().and_then(|u| {
                 // Fix the sign of `u` if necessary
                 let flip_sign = Choice::from((u.into_bytes()[0] ^ sign) & 1);
@@ -708,7 +708,7 @@ pub fn batch_normalize<'a>(v: &'a mut [ExtendedPoint]) -> impl Iterator<Item = A
     }
 
     // This is the inverse, as all z-coordinates are nonzero.
-    acc = acc.invert_nonzero();
+    acc = acc.invert().unwrap();
 
     for p in v.iter_mut().rev() {
         let mut q = *p;
@@ -745,7 +745,7 @@ fn test_is_on_curve_var() {
 fn test_d_is_non_quadratic_residue() {
     assert!(EDWARDS_D.sqrt().is_none().unwrap_u8() == 1);
     assert!((-EDWARDS_D).sqrt().is_none().unwrap_u8() == 1);
-    assert!((-EDWARDS_D).invert_nonzero().sqrt().is_none().unwrap_u8() == 1);
+    assert!((-EDWARDS_D).invert().unwrap().sqrt().is_none().unwrap_u8() == 1);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 #[macro_use]
 mod util;
 
+pub mod maybe;
+
 mod fq;
 mod fr;
 pub use fq::*;

--- a/src/maybe.rs
+++ b/src/maybe.rs
@@ -1,0 +1,140 @@
+//! This module provides a "Maybe" abstraction as a constant-time
+//! alternative for APIs that want to return optional values.
+//! Ideally, this would be merged into upstream `subtle` at some
+//! point.
+
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+/// The `Maybe<T>` type represents an optional value similar to the
+/// [`Option<T>`](core::option::Option) type but is intended for
+/// use in constant time APIs. Any given `Maybe<T>` is either
+/// `Some` or `None`, but unlike `Option<T>` these variants are
+/// not exposed. The `is_some()` method is used to determine if the
+/// value is `Some`, and `unwrap_or`/`unwrap_or_else` methods are
+/// provided to access the underlying value. The value can also be
+/// obtained with `unwrap()` but this will panic if it is None.
+///
+/// Functions that are intended to be constant time may not produce
+/// valid results for all inputs, such as square root and inversion
+/// operations in finite field arithmetic. Returning an `Option<T>`
+/// from these functions makes it difficult for the caller to reason
+/// about the result in constant time, and returning an incorrect
+/// value burdens the caller and increases the chance of bugs.
+#[derive(Clone, Copy, Debug)]
+pub struct Maybe<T> {
+    value: T,
+    is_some: Choice,
+}
+
+impl<T> Maybe<T> {
+    /// This method is used to construct a new `Maybe<T>` and takes
+    /// a value of type `T`, and a `Choice` that determines whether
+    /// the optional value should be `Some` or not. If `is_some` is
+    /// false, the value will still be stored but its value is never
+    /// exposed.
+    #[inline]
+    pub fn new(value: T, is_some: Choice) -> Maybe<T> {
+        Maybe { value, is_some }
+    }
+
+    /// This returns the underlying value but panics if it
+    /// is not `Some`.
+    #[inline]
+    pub fn unwrap(self) -> T {
+        assert_eq!(self.is_some.unwrap_u8(), 1);
+
+        self.value
+    }
+
+    /// This returns the underlying value if it is `Some`
+    /// or the provided value otherwise.
+    #[inline]
+    pub fn unwrap_or(self, def: T) -> T
+        where T: ConditionallySelectable
+    {
+        T::conditional_select(&def, &self.value, self.is_some)
+    }
+
+    /// This returns the underlying value if it is `Some`
+    /// or the value produced by the provided closure otherwise.
+    #[inline]
+    pub fn unwrap_or_else<F>(self, f: F) -> T
+        where T: ConditionallySelectable,
+              F: FnOnce() -> T
+    {
+        T::conditional_select(&f(), &self.value, self.is_some)
+    }
+
+    /// Returns a true `Choice` if this value is `Some`.
+    #[inline]
+    pub fn is_some(&self) -> Choice {
+        self.is_some
+    }
+
+    /// Returns a true `Choice` if this value is `None`.
+    #[inline]
+    pub fn is_none(&self) -> Choice {
+        !self.is_some
+    }
+}
+
+impl<T: ConstantTimeEq> ConstantTimeEq for Maybe<T> {
+    /// Two `Maybe<T>`s are equal if they are both `Some` and
+    /// their values are equal, or both `None`.
+    #[inline]
+    fn ct_eq(&self, rhs: &Maybe<T>) -> Choice {
+        let a = self.is_some();
+        let b = rhs.is_some();
+
+        (a & b & self.value.ct_eq(&rhs.value)) | (!a & !b)
+    }
+}
+
+
+#[test]
+fn test_maybe() {
+    let a = Maybe::new(10, Choice::from(1));
+    let b = Maybe::new(9, Choice::from(1));
+    let c = Maybe::new(10, Choice::from(0));
+    let d = Maybe::new(9, Choice::from(0));
+
+    // Test is_some / is_none
+    assert!(bool::from(a.is_some()));
+    assert!(bool::from(!a.is_none()));
+    assert!(bool::from(b.is_some()));
+    assert!(bool::from(!b.is_none()));
+    assert!(bool::from(!c.is_some()));
+    assert!(bool::from(c.is_none()));
+    assert!(bool::from(!d.is_some()));
+    assert!(bool::from(d.is_none()));
+
+    // Test unwrap for Some
+    assert_eq!(a.unwrap(), 10);
+    assert_eq!(b.unwrap(), 9);
+
+    // Test equality
+    assert!(bool::from(a.ct_eq(&a)));
+    assert!(bool::from(!a.ct_eq(&b)));
+    assert!(bool::from(!a.ct_eq(&c)));
+    assert!(bool::from(!a.ct_eq(&d)));
+
+    // Test equality of None with different
+    // dummy value
+    assert!(bool::from(c.ct_eq(&d)));
+
+    // Test unwrap_or
+    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or(2), 1);
+    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or(2), 2);
+
+    // Test unwrap_or_else
+    assert_eq!(Maybe::new(1, Choice::from(1)).unwrap_or_else(|| 2), 1);
+    assert_eq!(Maybe::new(1, Choice::from(0)).unwrap_or_else(|| 2), 2);
+}
+
+#[test]
+#[should_panic]
+fn unwrap_none_maybe() {
+    // This test might fail (in release mode?) if the
+    // compiler decides to optimize it away.
+    Maybe::new(10, Choice::from(0)).unwrap();
+}

--- a/tests/fq_blackbox.rs
+++ b/tests/fq_blackbox.rs
@@ -93,7 +93,7 @@ fn test_multiplicative_inverse() {
         if a == Fq::zero() {
             continue;
         }
-        let a_inv = a.invert_nonzero();
+        let a_inv = a.invert().unwrap();
         assert_eq!(Fq::one(), a * a_inv);
         assert_eq!(Fq::one(), a_inv * a);
     }

--- a/tests/fq_blackbox.rs
+++ b/tests/fq_blackbox.rs
@@ -8,7 +8,7 @@ fn test_to_and_from_bytes() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(a, Fq::from_bytes_vartime(Fq::into_bytes(&a)).unwrap());
+        assert_eq!(a, Fq::from_bytes(Fq::into_bytes(&a)).unwrap());
     }
 }
 

--- a/tests/fr_blackbox.rs
+++ b/tests/fr_blackbox.rs
@@ -8,7 +8,7 @@ fn test_to_and_from_bytes() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fr::new_random(&mut rng);
-        assert_eq!(a, Fr::from_bytes_vartime(Fr::into_bytes(&a)).unwrap());
+        assert_eq!(a, Fr::from_bytes(Fr::into_bytes(&a)).unwrap());
     }
 }
 

--- a/tests/fr_blackbox.rs
+++ b/tests/fr_blackbox.rs
@@ -93,7 +93,7 @@ fn test_multiplicative_inverse() {
         if a == Fr::zero() {
             continue;
         }
-        let a_inv = a.invert_nonzero();
+        let a_inv = a.invert().unwrap();
         assert_eq!(Fr::one(), a * a_inv);
         assert_eq!(Fr::one(), a_inv * a);
     }


### PR DESCRIPTION
This changes virtually everything to be constant time, by introducing a new `Maybe` abstraction that can [later](https://github.com/dalek-cryptography/subtle/pull/40) be upstream'd to `subtle`. This borrows from #18's constant time Tonelli-Shanks, adapted to match the current implementation that is more efficient and more closely based on the paper.

TODO: tests for `Maybe::and_then` and `Maybe::map`