### PR TITLE
Remove nightly note

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "1"
 default-features = false
 
 [dependencies.subtle]
-version = "2.1"
+version = "^2.2.1"
 default-features = false
 
 [dev-dependencies.rand_core]
@@ -31,5 +31,4 @@ default-features = false
 
 [features]
 default = ["std"]
-nightly = ["subtle/nightly"]
 std = []

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This is a pure Rust implementation of the Jubjub elliptic curve group and its as
 ## Features
 
 * `std` (on by default): Enables APIs that leverage the Rust standard library.
-* `nightly`: Enables `subtle/nightly` which prevents compiler optimizations that could jeopardize constant time operations.
 
 ## [Documentation](https://docs.rs/jubjub)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,7 @@
 //! All operations are constant time unless explicitly noted; these functions will contain
 //! "vartime" in their name and they will be documented as variable time.
 //!
-//! This crate relies on the `subtle` crate for achieving constant time arithmetic. It is
-//! recommended to enable the `nightly` feature on this crate (which enables the `nightly`
-//! feature in the `subtle` crate) to defend against compiler optimizations that may
-//! compromise constant time arithmetic. However, this requires use of the nightly version
-//! of the Rust compiler.
-//!
-//! # Features
-//!
-//! * `nightly`: This enables `subtle/nightly` which attempts to prevent the compiler from
-//! performing optimizations that could compromise constant time arithmetic. It is
-//! recommended to enable this if you are able to use a nightly version of the Rust compiler.
+//! This crate relies on the `subtle` crate for achieving constant time arithmetic.
 
 #![no_std]
 // Catch documentation errors caused by code changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! All operations are constant time unless explicitly noted; these functions will contain
 //! "vartime" in their name and they will be documented as variable time.
 //!
-//! This crate relies on the `subtle` crate for achieving constant time arithmetic.
+//! This crate uses the `subtle` crate to perform constant-time operations.
 
 #![no_std]
 // Catch documentation errors caused by code changes.


### PR DESCRIPTION
The nightly feature is not required since subtle 2.2.1.

