### PR TITLE
Fix ZIP 216 bug

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,15 @@
 # Unreleased
+## Security
+- A bug in the `jubjub::{AffinePoint, ExtendedPoint, SubgroupPoint}::from_bytes`
+  APIs (and their `group::GroupEncoding` implementations) has been fixed. The
+  APIs were documented as rejecting non-canonical points, but were accidentally
+  accepting two specific non-canonical encodings. This could potentially cause a
+  problem in consensus-critical protocols that expect encodings to be round-trip
+  compatible (i.e. `AffinePoint::from_bytes(b).unwrap().to_bytes() == b`). See
+  [ZIP 216](https://zips.z.cash/zip-0216) for more details.
+  - A new API `jubjub::AffinePoint::from_bytes_with_zip_216_bug` preserves the
+    previous behaviour for consensus compatibility.
+
 ## Changed
 - Bumped dependencies to `bitvec 0.22`, `bls12_381 0.5`, `ff 0.10`,
   `group 0.10`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,8 +7,9 @@
   problem in consensus-critical protocols that expect encodings to be round-trip
   compatible (i.e. `AffinePoint::from_bytes(b).unwrap().to_bytes() == b`). See
   [ZIP 216](https://zips.z.cash/zip-0216) for more details.
-  - A new API `jubjub::AffinePoint::from_bytes_with_zip_216_bug` preserves the
-    previous behaviour for consensus compatibility.
+  - A new API `jubjub::AffinePoint::from_bytes_pre_zip216_compatibility`
+    preserves the previous behaviour, for use where consensus compatibility is
+    required.
 
 ## Changed
 - Bumped dependencies to `bitvec 0.22`, `bls12_381 0.5`, `ff 0.10`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,7 +455,30 @@ impl AffinePoint {
     /// Attempts to interpret a byte representation of an
     /// affine point, failing if the element is not on
     /// the curve or non-canonical.
-    pub fn from_bytes(mut b: [u8; 32]) -> CtOption<Self> {
+    pub fn from_bytes(b: [u8; 32]) -> CtOption<Self> {
+        Self::from_bytes_inner(b, 1.into())
+    }
+
+    /// Attempts to interpret a byte representation of an affine point, failing if the
+    /// element is not on the curve.
+    ///
+    /// Most non-canonical encodings will also cause a failure. However, this API
+    /// preserves (for use in consensus-critical protocols) a bug in the parsing code that
+    /// caused two non-canonical encodings to be silently accepted:
+    ///
+    /// - (0, 1), which is the identity;
+    /// - (0, -1), which is a point of order two.
+    ///
+    /// Each of these has a single non-canonical encoding in which the value of the sign
+    /// bit is 1.
+    ///
+    /// See [ZIP 216](https://zips.z.cash/zip-0216) for a more detailed description of the
+    /// bug, as well as its fix.
+    pub fn from_bytes_with_zip_216_bug(b: [u8; 32]) -> CtOption<Self> {
+        Self::from_bytes_inner(b, 0.into())
+    }
+
+    fn from_bytes_inner(mut b: [u8; 32], zip_216_enabled: Choice) -> CtOption<Self> {
         // Grab the sign bit from the representation
         let sign = b[31] >> 7;
 
@@ -485,7 +508,16 @@ impl AffinePoint {
                     let u_negated = -u;
                     let final_u = Fq::conditional_select(&u, &u_negated, flip_sign);
 
-                    CtOption::new(AffinePoint { u: final_u, v }, Choice::from(1u8))
+                    // If u == 0, flip_sign == sign_bit. We therefore want to reject the
+                    // encoding as non-canonical if all of the following occur:
+                    // - ZIP 216 is enabled
+                    // - u == 0
+                    // - flip_sign == true
+                    let u_is_zero = u.ct_eq(&Fq::zero());
+                    CtOption::new(
+                        AffinePoint { u: final_u, v },
+                        !(zip_216_enabled & u_is_zero & flip_sign),
+                    )
                 })
         })
     }
@@ -1762,5 +1794,50 @@ fn test_serialization_consistency() {
         assert_eq!(affine, deserialized);
         assert_eq!(expected_serialized, serialized);
         p += gen;
+    }
+}
+
+#[test]
+fn test_zip_216() {
+    const NON_CANONICAL_ENCODINGS: [[u8; 32]; 2] = [
+        // (0, 1) with sign bit set to 1.
+        [
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x80,
+        ],
+        // (0, -1) with sign bit set to 1.
+        [
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xfe, 0x5b, 0xfe, 0xff, 0x02, 0xa4,
+            0xbd, 0x53, 0x05, 0xd8, 0xa1, 0x09, 0x08, 0xd8, 0x39, 0x33, 0x48, 0x7d, 0x9d, 0x29,
+            0x53, 0xa7, 0xed, 0xf3,
+        ],
+    ];
+
+    for b in &NON_CANONICAL_ENCODINGS {
+        {
+            let mut encoding = *b;
+
+            // The normal API should reject the non-canonical encoding.
+            assert!(bool::from(AffinePoint::from_bytes(encoding).is_none()));
+
+            // If we clear the sign bit of the non-canonical encoding, it should be
+            // accepted by the normal API.
+            encoding[31] &= 0b0111_1111;
+            assert!(bool::from(AffinePoint::from_bytes(encoding).is_some()));
+        }
+
+        {
+            // The bug-preserving API should accept the non-canonical encoding, and the
+            // resulting point should serialize to a different (canonical) encoding.
+            let parsed = AffinePoint::from_bytes_with_zip_216_bug(*b).unwrap();
+            let mut encoded = parsed.to_bytes();
+            assert_ne!(b, &encoded);
+
+            // If we set the sign bit of the serialized encoding, it should match the
+            // non-canonical encoding.
+            encoded[31] |= 0b1000_0000;
+            assert_eq!(b, &encoded);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl AffinePoint {
     ///
     /// Most non-canonical encodings will also cause a failure. However, this API
     /// preserves (for use in consensus-critical protocols) a bug in the parsing code that
-    /// caused two non-canonical encodings to be silently accepted:
+    /// caused two non-canonical encodings to be **silently** accepted:
     ///
     /// - (0, 1), which is the identity;
     /// - (0, -1), which is a point of order two.
@@ -474,7 +474,7 @@ impl AffinePoint {
     ///
     /// See [ZIP 216](https://zips.z.cash/zip-0216) for a more detailed description of the
     /// bug, as well as its fix.
-    pub fn from_bytes_with_zip_216_bug(b: [u8; 32]) -> CtOption<Self> {
+    pub fn from_bytes_pre_zip216_compatibility(b: [u8; 32]) -> CtOption<Self> {
         Self::from_bytes_inner(b, 0.into())
     }
 
@@ -1830,7 +1830,7 @@ fn test_zip_216() {
         {
             // The bug-preserving API should accept the non-canonical encoding, and the
             // resulting point should serialize to a different (canonical) encoding.
-            let parsed = AffinePoint::from_bytes_with_zip_216_bug(*b).unwrap();
+            let parsed = AffinePoint::from_bytes_pre_zip216_compatibility(*b).unwrap();
             let mut encoded = parsed.to_bytes();
             assert_ne!(b, &encoded);
 


### PR DESCRIPTION
See [ZIP 216](https://zips.z.cash/zip-0216) for more details.

A new API `jubjub::AffinePoint::from_bytes_pre_zip216_compatibility` has been added for consensus compatibility. We will use this API in Zcash code until NU5 activates.