### PR TITLE
Add `jubjub::AffinePoint::batch_from_bytes` API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+# Unreleased
+## Added
+- `jubjub::AffinePoint::batch_from_bytes`, which enables the inversion inside
+  `jubjub::AffinePoint::from_bytes` to be batched.
+
 # 0.7.0
 ## Security
 - A bug in the `jubjub::{AffinePoint, ExtendedPoint, SubgroupPoint}::from_bytes`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,8 @@ impl AffinePoint {
 
     /// Attempts to interpret a batch of byte representations of affine points.
     ///
-    /// Returns None for each element if it is not on the curve or is non-canonical.
+    /// Returns None for each element if it is not on the curve, or is non-canonical
+    /// according to ZIP 216.
     #[cfg(feature = "alloc")]
     pub fn batch_from_bytes(items: impl Iterator<Item = [u8; 32]>) -> Vec<CtOption<Self>> {
         #[derive(Clone, Copy, Default)]


### PR DESCRIPTION
This enables the inversion inside `jubjub::AffinePoint::from_bytes` to be batched.