### PR TITLE
chore(rust-toolchain.toml): update to newer rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.76.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
rust analyzer and `cargo test` both fail with dependecy error on rayon library, this fixes the issue. All tests passing